### PR TITLE
UCC: Update package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 junit.xml
 .DS_Store
 
+~/.npm

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "@DedalusDIIT/cornerstone-tools",
-  "version": "4.0.1",
+  "name": "@dedalusdiit/cornerstone-tools",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/DedalusDIIT/cornerstoneTools",
   "license": "MIT",
   "publishConfig": {
+    "cache": "~/.npm",
     "registry": "https://npm.pkg.github.com/"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
+  "version": "4.0.3",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '4.0.1';
+export default '4.0.3';


### PR DESCRIPTION
# What does this Merge Request do?

Updates package name as npm version 7 and its new package-lock format seem to have issues with capitalization in package versions.

Also, the property 'cache' is added to `publishConfig` in the package.json as otherwise `npm publish` fails with the newest npm version. (https://github.com/npm/cli/issues/2834)

Package with version 4.0.3 is published to reflect these changes.
<!-- Give a brief summary (1-2 sentences) what this Merge Request is about. -->