### PR TITLE
DVISA-1781: Annotation text method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.6-ded4-rc7",
+  "version": "6.0.6-ded5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.6-ded4-rc7",
+  "version": "6.0.6-ded5",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/src/tools/annotation/ArrowAnnotateTool.js
+++ b/src/tools/annotation/ArrowAnnotateTool.js
@@ -316,8 +316,6 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
     displayUncertainties,
     options = {}
   ) {
-    // TODO LISA: what to return here, there is no text
-    // should we add this method to all tools even those we are not using?
     return undefined;
   }
 

--- a/src/tools/annotation/ArrowAnnotateTool.js
+++ b/src/tools/annotation/ArrowAnnotateTool.js
@@ -307,6 +307,7 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
     );
   }
 
+  // Returns an empty string since the arrow does not draw any text
   static getToolTextFromToolState(
     context,
     isColorImage,
@@ -316,7 +317,7 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
     displayUncertainties,
     options = {}
   ) {
-    return undefined;
+    return '';
   }
 
   doubleClickCallback(evt) {

--- a/src/tools/annotation/ArrowAnnotateTool.js
+++ b/src/tools/annotation/ArrowAnnotateTool.js
@@ -122,6 +122,7 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
     const lineWidth = toolStyle.getToolWidth();
 
     let lineDash;
+
     if (renderDashed) {
       lineDash = getModule('globalConfiguration').configuration.lineDash;
     }
@@ -304,6 +305,20 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
         external.cornerstone.updateImage(element);
       }
     );
+  }
+
+  static getToolTextFromToolState(
+    context,
+    isColorImage,
+    toolState,
+    modality,
+    hasPixelSpacing,
+    displayUncertainties,
+    options = {}
+  ) {
+    // TODO LISA: what to return here, there is no text
+    // should we add this method to all tools even those we are not using?
+    return undefined;
   }
 
   doubleClickCallback(evt) {

--- a/src/tools/annotation/ArrowAnnotateTool.js
+++ b/src/tools/annotation/ArrowAnnotateTool.js
@@ -307,7 +307,9 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
     );
   }
 
-  // Returns an empty string since the arrow does not draw any text
+  /**
+   * Returns an empty string since the arrow does not draw any text
+   */
   static getToolTextFromToolState(
     context,
     isColorImage,

--- a/src/tools/annotation/ArrowAnnotateTool.test.js
+++ b/src/tools/annotation/ArrowAnnotateTool.test.js
@@ -1,0 +1,9 @@
+import ArrowAnnotateTool from './ArrowAnnotateTool.js';
+
+describe('ArrowAnnotateTool.js', () => {
+  it('#getToolTextFromToolState should return an empty string', () => {
+    const text = ArrowAnnotateTool.getToolTextFromToolState();
+
+    expect(text).toEqual('');
+  });
+});

--- a/src/tools/annotation/CircleRoiTool.js
+++ b/src/tools/annotation/CircleRoiTool.js
@@ -293,6 +293,10 @@ export default class CircleRoiTool extends BaseMeasurementTool {
     });
   }
 
+  /**
+   * Static method which returns based on the given parameters the formatted text.
+   * The text is in the same format as it is also drawn on the canvas in the end.
+   **/
   static getToolTextFromToolState(
     context,
     isColorImage,

--- a/src/tools/annotation/CircleRoiTool.js
+++ b/src/tools/annotation/CircleRoiTool.js
@@ -292,6 +292,50 @@ export default class CircleRoiTool extends BaseMeasurementTool {
       }
     });
   }
+
+  static getToolTextFromToolState(
+    context,
+    isColorImage,
+    toolState, // cachedStats: { Area, areaUncertainty, mean, stdDev, min, max, meanStdDevSUV, diameter, diameterUncertainty, radius }
+    modality,
+    hasPixelSpacing,
+    displayUncertainties,
+    options = {}
+  ) {
+    const {
+      area,
+      areaUncertainty,
+      mean,
+      stdDev,
+      min,
+      max,
+      meanStdDevSUV,
+      diameter,
+      diameterUncertainty,
+      radius,
+    } = toolState.cachedStats;
+
+    return _createTextBoxContent(
+      context,
+      isColorImage,
+      {
+        area,
+        areaUncertainty,
+        mean,
+        stdDev,
+        min,
+        max,
+        meanStdDevSUV,
+        diameter,
+        diameterUncertainty,
+        radius,
+      },
+      modality,
+      hasPixelSpacing,
+      displayUncertainties,
+      options
+    );
+  }
 }
 
 /**

--- a/src/tools/annotation/CircleRoiTool.js
+++ b/src/tools/annotation/CircleRoiTool.js
@@ -334,7 +334,7 @@ export default class CircleRoiTool extends BaseMeasurementTool {
       hasPixelSpacing,
       displayUncertainties,
       options
-    );
+    ).join('\n');
   }
 }
 

--- a/src/tools/annotation/CircleRoiTool.test.js
+++ b/src/tools/annotation/CircleRoiTool.test.js
@@ -475,4 +475,49 @@ describe('CircleRoiTool.js', () => {
       });
     });
   });
+
+  describe('getToolTextFromToolState', () => {
+    it('should return the formatted text', () => {
+      // Arrange
+      formatArea.mockReturnValue('A: 1 mm2');
+      formatDiameter.mockReturnValue('d: 8 mm');
+
+      const context = {
+        measureText: jest.fn().mockReturnValue({ width: 100 }),
+      };
+      const isColorImage = false;
+      const toolState = {
+        cachedStats: {
+          area: 1,
+          areaUncertainty: 2,
+          mean: 3,
+          stdDev: 4,
+          min: 5,
+          max: 6,
+          meanStdDevSUV: undefined,
+          diameter: 8,
+          diameterUncertainty: 9,
+          radius: 10,
+        },
+      };
+      const modality = 'CT';
+      const hasPixelSpacing = true;
+      const displayUncertainties = true;
+
+      // Act
+      const text = CircleRoiTool.getToolTextFromToolState(
+        context,
+        isColorImage,
+        toolState,
+        modality,
+        hasPixelSpacing,
+        displayUncertainties
+      );
+
+      // Assert
+      expect(text).toBe(
+        'A: 1 mm2\nd: 8 mm\naverage: 3 HU\nstandardDeviation: 4 HU'
+      );
+    });
+  });
 });

--- a/src/tools/annotation/CobbAngleTool.js
+++ b/src/tools/annotation/CobbAngleTool.js
@@ -397,6 +397,10 @@ export default class CobbAngleTool extends BaseAnnotationTool {
     data.value = this.textBoxText(data);
   }
 
+  /**
+   * Static method which returns based on the given parameters the formatted text.
+   * The text is in the same format as it is also drawn on the canvas in the end.
+   **/
   static getToolTextFromToolState(
     context,
     isColorImage,

--- a/src/tools/annotation/CobbAngleTool.js
+++ b/src/tools/annotation/CobbAngleTool.js
@@ -397,6 +397,21 @@ export default class CobbAngleTool extends BaseAnnotationTool {
     data.value = this.textBoxText(data);
   }
 
+  static getToolTextFromToolState(
+    context,
+    isColorImage,
+    toolState, // AlphaAngle, betaAngle
+    modality,
+    hasPixelSpacing,
+    displayUncertainties,
+    options = {}
+  ) {
+    const { alphaAngle, betaAngle } = toolState;
+
+    // TODO LISA: this does not work
+    return this.textBoxText({ alphaAngle, betaAngle });
+  }
+
   textBoxText({ alphaAngle, betaAngle }) {
     if (alphaAngle === undefined) {
       return '';

--- a/src/tools/annotation/CobbAngleTool.js
+++ b/src/tools/annotation/CobbAngleTool.js
@@ -408,21 +408,11 @@ export default class CobbAngleTool extends BaseAnnotationTool {
   ) {
     const { alphaAngle, betaAngle } = toolState;
 
-    // TODO LISA: this does not work
-    return this.textBoxText({ alphaAngle, betaAngle });
+    return _createTextBoxContent({ alphaAngle, betaAngle });
   }
 
   textBoxText({ alphaAngle, betaAngle }) {
-    if (alphaAngle === undefined) {
-      return '';
-    }
-    if (Number.isNaN(alphaAngle)) {
-      return '';
-    }
-
-    return `${localization.localizeNumber(
-      alphaAngle
-    )}\u00B0, ${localization.localizeNumber(betaAngle)}\u00B0`;
+    return _createTextBoxContent({ alphaAngle, betaAngle });
   }
 
   activeCallback(element) {
@@ -454,4 +444,17 @@ export default class CobbAngleTool extends BaseAnnotationTool {
       this.onMeasureModified
     );
   }
+}
+
+function _createTextBoxContent({ alphaAngle, betaAngle }) {
+  if (alphaAngle === undefined) {
+    return '';
+  }
+  if (Number.isNaN(alphaAngle)) {
+    return '';
+  }
+
+  return `${localization.localizeNumber(
+    alphaAngle
+  )}\u00B0, ${localization.localizeNumber(betaAngle)}\u00B0`;
 }

--- a/src/tools/annotation/CobbAngleTool.test.js
+++ b/src/tools/annotation/CobbAngleTool.test.js
@@ -1,13 +1,19 @@
 import Tool from './CobbAngleTool.js';
 import { getToolState } from '../../stateManagement/toolState.js';
-import Decimal from 'decimal.js';
 import external from '../../externalModules.js';
+import { localizeNumber } from '../../util/localization/localization.utils.js';
 
 jest.mock('./../../stateManagement/toolState.js', () => ({
   getToolState: jest.fn(),
 }));
 
 jest.mock('./../../externalModules.js');
+
+jest.mock('../../util/localization/localization.utils', () => ({
+  __esModule: true,
+  translate: jest.fn(val => val),
+  localizeNumber: jest.fn(val => val),
+}));
 
 const goodMouseEventData = {
   currentPoints: {
@@ -233,6 +239,36 @@ describe('CobbAngleTool.js', () => {
       const renderResult = instantiatedTool.renderToolData(mockEvent);
 
       expect(renderResult).toBe(undefined);
+    });
+  });
+
+  describe('getToolTextFromToolState', () => {
+    it('should return the formatted text', () => {
+      // Arrange
+      localizeNumber.mockReturnValueOnce('10');
+      localizeNumber.mockReturnValueOnce('60');
+      const context = {};
+      const isColorImage = false;
+      const toolState = {
+        alphaAngle: 10,
+        betaAngle: 60,
+      };
+      const modality = 'CT';
+      const hasPixelSpacing = true;
+      const displayUncertainties = true;
+
+      // Act
+      const text = Tool.getToolTextFromToolState(
+        context,
+        isColorImage,
+        toolState,
+        modality,
+        hasPixelSpacing,
+        displayUncertainties
+      );
+
+      // Assert
+      expect(text).toBe('10°, 60°');
     });
   });
 });

--- a/src/tools/annotation/LengthTool.js
+++ b/src/tools/annotation/LengthTool.js
@@ -296,6 +296,10 @@ export default class LengthTool extends BaseMeasurementTool {
     }
   }
 
+  /**
+   * Static method which returns based on the given parameters the formatted text.
+   * The text is in the same format as it is also drawn on the canvas in the end.
+   **/
   static getToolTextFromToolState(
     context,
     isColorImage,

--- a/src/tools/annotation/LengthTool.js
+++ b/src/tools/annotation/LengthTool.js
@@ -254,10 +254,11 @@ export default class LengthTool extends BaseMeasurementTool {
           }
         }
 
+        const hasPixelSpacing = Boolean(rowPixelSpacing && colPixelSpacing);
+
         const text = textBoxText(
           data,
-          rowPixelSpacing,
-          colPixelSpacing,
+          hasPixelSpacing,
           this.displayUncertainties
         );
 
@@ -277,20 +278,10 @@ export default class LengthTool extends BaseMeasurementTool {
     }
 
     // - SideEffect: Updates annotation 'suffix'
-    function textBoxText(
-      annotation,
-      rowPixelSpacing,
-      colPixelSpacing,
-      displayUncertainties
-    ) {
-      const measuredValue = _sanitizeMeasuredValue(annotation.length);
-
-      const hasPixelSpacing = Boolean(rowPixelSpacing && colPixelSpacing);
-
-      return formatLenght(
-        measuredValue,
+    function textBoxText(annotation, hasPixelSpacing, displayUncertainties) {
+      return _createTextBoxContent(
+        annotation,
         hasPixelSpacing,
-        annotation.uncertainty,
         displayUncertainties
       );
     }
@@ -305,7 +296,21 @@ export default class LengthTool extends BaseMeasurementTool {
     }
   }
 
-  // TODO LISA: implement getToolTextFromToolState method
+  static getToolTextFromToolState(
+    context,
+    isColorImage,
+    toolState, // Length
+    modality,
+    hasPixelSpacing,
+    displayUncertainties,
+    options = {}
+  ) {
+    return _createTextBoxContent(
+      toolState,
+      hasPixelSpacing,
+      displayUncertainties
+    );
+  }
 }
 
 /**
@@ -320,4 +325,19 @@ function _sanitizeMeasuredValue(value) {
   const isNumber = !isNaN(parsedValue);
 
   return isNumber ? parsedValue : undefined;
+}
+
+function _createTextBoxContent(
+  annotation,
+  hasPixelSpacing,
+  displayUncertainties
+) {
+  const measuredValue = _sanitizeMeasuredValue(annotation.length);
+
+  return formatLenght(
+    measuredValue,
+    hasPixelSpacing,
+    annotation.uncertainty,
+    displayUncertainties
+  );
 }

--- a/src/tools/annotation/LengthTool.js
+++ b/src/tools/annotation/LengthTool.js
@@ -304,6 +304,8 @@ export default class LengthTool extends BaseMeasurementTool {
       return [handles.start, midpoint, handles.end];
     }
   }
+
+  // TODO LISA: implement getToolTextFromToolState method
 }
 
 /**

--- a/src/tools/annotation/LengthTool.test.js
+++ b/src/tools/annotation/LengthTool.test.js
@@ -303,4 +303,33 @@ describe('LengthTool.js', () => {
       });
     });
   });
+
+  describe('getToolTextFromToolState', () => {
+    it('should return the formatted text', () => {
+      // Arrange
+      formatLenght.mockReturnValue('10 mm');
+
+      const context = {};
+      const isColorImage = false;
+      const toolState = {
+        length: 10,
+      };
+      const modality = 'CT';
+      const hasPixelSpacing = true;
+      const displayUncertainties = true;
+
+      // Act
+      const text = LengthTool.getToolTextFromToolState(
+        context,
+        isColorImage,
+        toolState,
+        modality,
+        hasPixelSpacing,
+        displayUncertainties
+      );
+
+      // Assert
+      expect(text).toBe('10 mm');
+    });
+  });
 });

--- a/src/tools/annotation/RectangleRoiTool.js
+++ b/src/tools/annotation/RectangleRoiTool.js
@@ -302,8 +302,6 @@ export default class RectangleRoiTool extends BaseMeasurementTool {
       meanStdDevSUV,
     } = toolState.cachedStats;
 
-    console.log('TEST', toolState);
-
     return _createTextBoxContent(
       context,
       isColorImage,
@@ -312,7 +310,7 @@ export default class RectangleRoiTool extends BaseMeasurementTool {
       hasPixelSpacing,
       displayUncertainties,
       options
-    );
+    ).join('\n');
   }
 }
 

--- a/src/tools/annotation/RectangleRoiTool.js
+++ b/src/tools/annotation/RectangleRoiTool.js
@@ -283,6 +283,10 @@ export default class RectangleRoiTool extends BaseMeasurementTool {
     });
   }
 
+  /**
+   * Static method which returns based on the given parameters the formatted text.
+   * The text is in the same format as it is also drawn on the canvas in the end.
+   **/
   static getToolTextFromToolState(
     context,
     isColorImage,

--- a/src/tools/annotation/RectangleRoiTool.js
+++ b/src/tools/annotation/RectangleRoiTool.js
@@ -254,6 +254,7 @@ export default class RectangleRoiTool extends BaseMeasurementTool {
 
         const textBoxAnchorPoints = handles =>
           _findTextBoxAnchorPoints(handles.start, handles.end);
+
         const textBoxContent = _createTextBoxContent(
           context,
           image.color,
@@ -280,6 +281,38 @@ export default class RectangleRoiTool extends BaseMeasurementTool {
         );
       }
     });
+  }
+
+  static getToolTextFromToolState(
+    context,
+    isColorImage,
+    toolState, // cachedStats: { Area, areaUncertainty, mean, stdDev, min, max, meanStdDevSUV }
+    modality,
+    hasPixelSpacing,
+    displayUncertainties,
+    options = {}
+  ) {
+    const {
+      area,
+      areaUncertainty,
+      mean,
+      stdDev,
+      min,
+      max,
+      meanStdDevSUV,
+    } = toolState.cachedStats;
+
+    console.log('TEST', toolState);
+
+    return _createTextBoxContent(
+      context,
+      isColorImage,
+      { area, areaUncertainty, mean, stdDev, min, max, meanStdDevSUV },
+      modality,
+      hasPixelSpacing,
+      displayUncertainties,
+      options
+    );
   }
 }
 

--- a/src/tools/annotation/RectangleRoiTool.test.js
+++ b/src/tools/annotation/RectangleRoiTool.test.js
@@ -370,4 +370,43 @@ describe('RectangleRoiTool.js', () => {
       });
     });
   });
+
+  describe('getToolTextFromToolState', () => {
+    it('should return the formatted text', () => {
+      // Arrange
+      formatArea.mockReturnValue('A: 1 mm2');
+
+      const context = {
+        measureText: jest.fn().mockReturnValue({ width: 100 }),
+      };
+      const isColorImage = false;
+      const toolState = {
+        cachedStats: {
+          area: 1,
+          areaUncertainty: 2,
+          mean: 3,
+          stdDev: 4,
+          min: 5,
+          max: 6,
+          meanStdDevSUV: undefined,
+        },
+      };
+      const modality = 'CT';
+      const hasPixelSpacing = true;
+      const displayUncertainties = true;
+
+      // Act
+      const text = RectangleRoiTool.getToolTextFromToolState(
+        context,
+        isColorImage,
+        toolState,
+        modality,
+        hasPixelSpacing,
+        displayUncertainties
+      );
+
+      // Assert
+      expect(text).toBe('A: 1 mm2\naverage: 3 HU\nstandardDeviation: 4 HU');
+    });
+  });
 });

--- a/src/tools/annotation/TextMarkerTool.js
+++ b/src/tools/annotation/TextMarkerTool.js
@@ -214,6 +214,9 @@ export default class TextMarkerTool extends BaseAnnotationTool {
     }
   }
 
+  /**
+   * Static method which returns the text which is drawn on the canvas in the end.
+   **/
   static getToolTextFromToolState(
     context,
     isColorImage,

--- a/src/tools/annotation/TextMarkerTool.js
+++ b/src/tools/annotation/TextMarkerTool.js
@@ -213,6 +213,18 @@ export default class TextMarkerTool extends BaseAnnotationTool {
       }
     }
   }
+
+  static getToolTextFromToolState(
+    context,
+    isColorImage,
+    toolState,
+    modality,
+    hasPixelSpacing,
+    displayUncertainties,
+    options = {}
+  ) {
+    return toolState.text;
+  }
 }
 
 /**

--- a/src/tools/annotation/TextMarkerTool.spec.js
+++ b/src/tools/annotation/TextMarkerTool.spec.js
@@ -1,0 +1,28 @@
+import TextMarkerTool from './TextMarkerTool.js';
+
+describe('TextMarkerTool.js', () => {
+  it('#getToolTextFromToolState should return the tools text', () => {
+    // Arrange
+    const context = {};
+    const isColorImage = false;
+    const toolState = {
+      text: 'Text',
+    };
+    const modality = 'CT';
+    const hasPixelSpacing = true;
+    const displayUncertainties = true;
+
+    // Act
+    const text = TextMarkerTool.getToolTextFromToolState(
+      context,
+      isColorImage,
+      toolState,
+      modality,
+      hasPixelSpacing,
+      displayUncertainties
+    );
+
+    // Assert
+    expect(text).toEqual('Text');
+  });
+});

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '6.0.6-ded4-rc7';
+export default '6.0.6-ded5';


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Task:  It adds a new method `getToolTextFromToolState` to all tools. It returns per tool the text which ends up being drawn on the canvas. 
Implemention of ticket DVISA-1781.


* **What is the current behavior?** (You can also link to an open issue here)
There was no way of getting the drawn text from outside of cornerstone tools, because the text is not part of the toolstate.


* **What is the new behavior (if this is a feature change)?**
By using the static method getToolTextFromToolState it is now possible to get the text of each tool. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

