### PR TITLE
DVISA-1994: fix area unit for projection pixel spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.10-ded10-rc1",
+  "version": "6.0.10-ded10-rc2",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/src/util/formatMeasurement.js
+++ b/src/util/formatMeasurement.js
@@ -89,9 +89,17 @@ function formatDiameter(diameter, unit, uncertainty, displayUncertainties) {
 
 function _getAreaMeasurmentSuffix(unit) {
   const squareCharacter = String.fromCharCode(178);
-  const preffix = translate(unit);
+  const translatedUnit = translate(unit);
 
-  return `${preffix}${squareCharacter}`;
+  // If there is a space in the unit, the square character needs to be placed inbetween
+  if (translatedUnit.includes(' ')) {
+    const prefix = translatedUnit.split(' ')[0];
+    const suffix = translatedUnit.split(' ')[1];
+
+    return `${prefix}${squareCharacter} ${suffix}`;
+  }
+
+  return `${translatedUnit}${squareCharacter}`;
 }
 
 export { formatArea, formatLenght, formatDiameter };

--- a/src/util/formatMeasurement.test.js
+++ b/src/util/formatMeasurement.test.js
@@ -62,6 +62,11 @@ describe('formatMeasurement', () => {
         expected: 'area: 1260 mm²',
       },
       {
+        unit: 'mm (prj/est)',
+        displayUncertainties: false,
+        expected: 'area: 1260 mm² (prj/est)',
+      },
+      {
         displayUncertainties: true,
         unit: 'mm',
         expected: 'area: 1260 mm² +/- 180 mm²',

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '6.0.10-ded10-rc1';
+export default '6.0.10-ded10-rc2';


### PR DESCRIPTION
For projection radiographic images with units different than "mm" the square for the area measurement has to be placed between the "mm" and the suffix. For example, for unit "mm (prj/est)" the area measurement unit is now "mm2 (prj/est)" and not "mm (prj/est)2" as it was.