### PR TITLE
DVISA-2576: LiveSync Tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=8.16.0"
   },
   "scripts": {
-    "build": "npm run clean:dist && npm run version && npm run build:prod && npm run build:dev",
+    "build": "npm run test && npm run clean:dist && npm run version && npm run build:prod && npm run build:dev",
     "build:dev": "webpack --progress --config ./config/webpack/webpack-dev",
     "build:prod": "webpack --config ./config/webpack/webpack-prod",
     "commit": "git-cz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.10-ded15",
+  "version": "6.0.10-ded16",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [
@@ -24,7 +24,7 @@
     "node": ">=8.16.0"
   },
   "scripts": {
-    "build": "npm run test && npm run clean:dist && npm run version && npm run build:prod && npm run build:dev",
+    "build": "npm run clean:dist && npm run version && npm run build:prod && npm run build:dev",
     "build:dev": "webpack --progress --config ./config/webpack/webpack-dev",
     "build:prod": "webpack --config ./config/webpack/webpack-prod",
     "commit": "git-cz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.10-ded16",
+  "version": "6.0.10-ded17",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/src/tools/CrosshairsTool.js
+++ b/src/tools/CrosshairsTool.js
@@ -55,8 +55,6 @@ export default class CrosshairsTool extends BaseTool {
     const toolData = getToolState(element, this.name);
 
     if (!toolData) {
-      console.log('no tooldata');
-
       return;
     }
 
@@ -79,8 +77,6 @@ export default class CrosshairsTool extends BaseTool {
       !sourceImagePlane.columnPixelSpacing ||
       !sourceImagePlane.rowPixelSpacing
     ) {
-      console.log('missing information from imagePlane', sourceImagePlane);
-
       return;
     }
 

--- a/src/tools/CrosshairsTool.js
+++ b/src/tools/CrosshairsTool.js
@@ -55,6 +55,8 @@ export default class CrosshairsTool extends BaseTool {
     const toolData = getToolState(element, this.name);
 
     if (!toolData) {
+      console.log('no tooldata');
+
       return;
     }
 
@@ -77,6 +79,8 @@ export default class CrosshairsTool extends BaseTool {
       !sourceImagePlane.columnPixelSpacing ||
       !sourceImagePlane.rowPixelSpacing
     ) {
+      console.log('missing information from imagePlane', sourceImagePlane);
+
       return;
     }
 

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '6.0.10-ded15';
+export default '6.0.10-ded16';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '6.0.10-ded16';
+export default '6.0.10-ded17';


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Two minor adaptations to the CrosshairsTool: 
1. add a callback which is called whenever the new image is displayed including information about the target element, image id and image index. 
2. in the case of series not supporting LiveSync the tool would throw an error, this is fixed now by checking whether all needed fields are available or not. 

Note: the cornerstoneTools version was changed from 15 to 18 since some in-between versions were needed to debug and test the changes in the viewer deployments.

