### PR TITLE
DVISA-1217: LiveSync functionality - 2nd part

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.10-ded21",
+  "version": "6.0.10-ded22",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.10-ded18",
+  "version": "6.0.10-ded19",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.10-ded20",
+  "version": "6.0.10-ded21",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.10-ded17",
+  "version": "6.0.10-ded18",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.10-ded19",
+  "version": "6.0.10-ded20",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/src/tools/CrosshairsTool.js
+++ b/src/tools/CrosshairsTool.js
@@ -110,6 +110,32 @@ export default class CrosshairsTool extends BaseTool {
         return;
       }
 
+      const targetImage = external.cornerstone.getEnabledElement(targetElement)
+        .image;
+      const sourceImage = external.cornerstone.getEnabledElement(sourceElement)
+        .image;
+
+      if (!targetImage || !sourceImage) {
+        return;
+      }
+
+      const targetImagePlane = external.cornerstone.metaData.get(
+        'imagePlaneModule',
+        targetImage.imageId
+      );
+      const sourceImagePlane = external.cornerstone.metaData.get(
+        'imagePlaneModule',
+        sourceImage.imageId
+      );
+
+      // The image planes must be in the same frame of reference
+      if (
+        targetImagePlane.frameOfReferenceUID !==
+        sourceImagePlane.frameOfReferenceUID
+      ) {
+        return;
+      }
+
       let minDistance = Number.MAX_VALUE;
       let newImageIdIndex = -1;
 

--- a/src/tools/CrosshairsTool.js
+++ b/src/tools/CrosshairsTool.js
@@ -225,6 +225,8 @@ export default class CrosshairsTool extends BaseTool {
       context
     );
     enabledElements.forEach(referenceEnabledElement => {
+      const evtCurrentTarget = evt.currentTarget;
+
       // Don't draw ourselves
       if (referenceEnabledElement === evt.currentTarget) {
         return;
@@ -236,7 +238,7 @@ export default class CrosshairsTool extends BaseTool {
 
       referenceEnabledElement.addEventListener(
         external.cornerstone.EVENTS.IMAGE_RENDERED,
-        renderEvt => {
+        () => {
           if (this.mode === 'disabled') {
             return;
           }
@@ -245,7 +247,7 @@ export default class CrosshairsTool extends BaseTool {
           this.renderer(
             enabledElementContext,
             eventData,
-            renderEvt.currentTarget,
+            evtCurrentTarget,
             referenceEnabledElement,
             this.mainPatientPoint
           );

--- a/src/tools/CrosshairsTool.js
+++ b/src/tools/CrosshairsTool.js
@@ -99,7 +99,6 @@ export default class CrosshairsTool extends BaseTool {
     );
 
     this.mainPatientPoint = patientPoint;
-    console.log('log _chooseLocation');
 
     // Get the enabled elements associated with this synchronization context
     this.synchronizationContext = toolData.data[0].synchronizationContext;
@@ -215,8 +214,6 @@ export default class CrosshairsTool extends BaseTool {
   }
 
   renderToolData(evt) {
-    console.log('log renderToolData');
-
     const eventData = evt.detail;
 
     // No renderer or synch context? Adios
@@ -245,6 +242,10 @@ export default class CrosshairsTool extends BaseTool {
       referenceEnabledElement.addEventListener(
         external.cornerstone.EVENTS.IMAGE_RENDERED,
         renderEvt => {
+          if (this.mode === 'disabled') {
+            return;
+          }
+
           // Render it
           this.renderer(
             enabledElementContext,

--- a/src/tools/CrosshairsTool.js
+++ b/src/tools/CrosshairsTool.js
@@ -41,7 +41,6 @@ export default class CrosshairsTool extends BaseTool {
     this.touchDragCallback = this._chooseLocation.bind(this);
     this.renderer = this.configuration.renderer;
     this.synchronizationContext = null;
-    this.projectedPatientPoint = null;
     this.mainPatientPoint = null;
   }
 

--- a/src/tools/CrosshairsTool.js
+++ b/src/tools/CrosshairsTool.js
@@ -152,10 +152,6 @@ export default class CrosshairsTool extends BaseTool {
         }
       });
 
-      if (newImageIdIndex === stackData.currentImageIdIndex) {
-        return;
-      }
-
       // Switch the loaded image to the required image
       if (
         newImageIdIndex !== -1 &&

--- a/src/tools/CrosshairsTool.js
+++ b/src/tools/CrosshairsTool.js
@@ -242,13 +242,19 @@ export default class CrosshairsTool extends BaseTool {
       ).canvas;
       const enabledElementContext = getNewContext(enabledElementCanvas);
 
-      // Render it
-      this.renderer(
-        enabledElementContext,
-        eventData,
-        evt.currentTarget,
-        referenceEnabledElement,
-        this.mainPatientPoint
+      referenceEnabledElement.addEventListener(
+        external.cornerstone.EVENTS.IMAGE_RENDERED,
+        renderEvt => {
+          // Render it
+          this.renderer(
+            enabledElementContext,
+            eventData,
+            renderEvt.currentTarget,
+            referenceEnabledElement,
+            this.mainPatientPoint
+          );
+        },
+        { once: true }
       );
     });
   }

--- a/src/tools/crosshairs/renderCrosshairs.js
+++ b/src/tools/crosshairs/renderCrosshairs.js
@@ -85,7 +85,7 @@ export default function(
 
   const color = '#A8D7FD';
 
-  // Draw the referenceLines
+  // Draw the crosshairs
   context.setTransform(1, 0, 0, 1, 0, 0);
 
   const verticalLine1Start = { x: projectedPatientPoint.x, y: 0 };

--- a/src/tools/crosshairs/renderCrosshairs.js
+++ b/src/tools/crosshairs/renderCrosshairs.js
@@ -88,18 +88,60 @@ export default function(
   // Draw the referenceLines
   context.setTransform(1, 0, 0, 1, 0, 0);
 
-  const line1Start = { x: projectedPatientPoint.x, y: 0 };
-  const line1End = { x: projectedPatientPoint.x, y: referenceImage.height };
-  const line2Start = { x: 0, y: projectedPatientPoint.y };
-  const line2End = { x: referenceImage.width, y: projectedPatientPoint.y };
+  const verticalLine1Start = { x: projectedPatientPoint.x, y: 0 };
+  const verticalLine1End = {
+    x: projectedPatientPoint.x,
+    y: projectedPatientPoint.y - 15,
+  };
+  const verticalLine2Start = {
+    x: projectedPatientPoint.x,
+    y: projectedPatientPoint.y + 15,
+  };
+  const verticalLine2End = {
+    x: projectedPatientPoint.x,
+    y: referenceImage.height,
+  };
+  const horizontalLine1Start = { x: 0, y: projectedPatientPoint.y };
+  const horizontalLine1End = {
+    x: projectedPatientPoint.x - 15,
+    y: projectedPatientPoint.y,
+  };
+  const horizontalLine2Start = {
+    x: projectedPatientPoint.x + 15,
+    y: projectedPatientPoint.y,
+  };
+  const horizontalLine2End = {
+    x: referenceImage.width,
+    y: projectedPatientPoint.y,
+  };
 
   draw(context, context => {
-    drawLine(context, referenceElement, line1Start, line1End, {
+    drawLine(context, referenceElement, verticalLine1Start, verticalLine1End, {
       color,
     });
 
-    drawLine(context, referenceElement, line2Start, line2End, {
+    drawLine(context, referenceElement, verticalLine2Start, verticalLine2End, {
       color,
     });
+
+    drawLine(
+      context,
+      referenceElement,
+      horizontalLine1Start,
+      horizontalLine1End,
+      {
+        color,
+      }
+    );
+
+    drawLine(
+      context,
+      referenceElement,
+      horizontalLine2Start,
+      horizontalLine2End,
+      {
+        color,
+      }
+    );
   });
 }

--- a/src/tools/crosshairs/renderCrosshairs.js
+++ b/src/tools/crosshairs/renderCrosshairs.js
@@ -88,60 +88,113 @@ export default function(
   // Draw the crosshairs
   context.setTransform(1, 0, 0, 1, 0, 0);
 
-  const verticalLine1Start = { x: projectedPatientPoint.x, y: 0 };
-  const verticalLine1End = {
-    x: projectedPatientPoint.x,
-    y: projectedPatientPoint.y - 15,
+  const boundaryCoordinates = {
+    x: Math.max(0, Math.min(referenceImage.width, projectedPatientPoint.x)),
+    y: Math.max(0, Math.min(referenceImage.height, projectedPatientPoint.y)),
   };
-  const verticalLine2Start = {
-    x: projectedPatientPoint.x,
-    y: projectedPatientPoint.y + 15,
-  };
-  const verticalLine2End = {
-    x: projectedPatientPoint.x,
-    y: referenceImage.height,
-  };
-  const horizontalLine1Start = { x: 0, y: projectedPatientPoint.y };
-  const horizontalLine1End = {
-    x: projectedPatientPoint.x - 15,
-    y: projectedPatientPoint.y,
-  };
-  const horizontalLine2Start = {
-    x: projectedPatientPoint.x + 15,
-    y: projectedPatientPoint.y,
-  };
-  const horizontalLine2End = {
-    x: referenceImage.width,
-    y: projectedPatientPoint.y,
-  };
+
+  const gapSize = 15;
+
+  // Calculate vertical line segments with boundary checks
+  let verticalLine1Start,
+    verticalLine1End,
+    verticalLine2Start,
+    verticalLine2End;
+
+  if (boundaryCoordinates.y - gapSize > 0) {
+    verticalLine1Start = { x: boundaryCoordinates.x, y: 0 };
+    verticalLine1End = {
+      x: boundaryCoordinates.x,
+      y: boundaryCoordinates.y - gapSize,
+    };
+  } else {
+    verticalLine1Start = verticalLine1End = null;
+  }
+
+  if (boundaryCoordinates.y + gapSize < referenceImage.height) {
+    verticalLine2Start = {
+      x: boundaryCoordinates.x,
+      y: boundaryCoordinates.y + gapSize,
+    };
+    verticalLine2End = { x: boundaryCoordinates.x, y: referenceImage.height };
+  } else {
+    verticalLine2Start = verticalLine2End = null;
+  }
+
+  // Calculate horizontal line segments with boundary checks
+  let horizontalLine1Start,
+    horizontalLine1End,
+    horizontalLine2Start,
+    horizontalLine2End;
+
+  if (boundaryCoordinates.x - gapSize > 0) {
+    horizontalLine1Start = { x: 0, y: boundaryCoordinates.y };
+    horizontalLine1End = {
+      x: boundaryCoordinates.x - gapSize,
+      y: boundaryCoordinates.y,
+    };
+  } else {
+    horizontalLine1Start = horizontalLine1End = null;
+  }
+
+  if (boundaryCoordinates.x + gapSize < referenceImage.width) {
+    horizontalLine2Start = {
+      x: boundaryCoordinates.x + gapSize,
+      y: boundaryCoordinates.y,
+    };
+    horizontalLine2End = { x: referenceImage.width, y: boundaryCoordinates.y };
+  } else {
+    horizontalLine2Start = horizontalLine2End = null;
+  }
 
   draw(context, context => {
-    drawLine(context, referenceElement, verticalLine1Start, verticalLine1End, {
-      color,
-    });
+    // Only draw lines if their endpoints are valid
+    if (verticalLine1Start && verticalLine1End) {
+      drawLine(
+        context,
+        referenceElement,
+        verticalLine1Start,
+        verticalLine1End,
+        {
+          color,
+        }
+      );
+    }
 
-    drawLine(context, referenceElement, verticalLine2Start, verticalLine2End, {
-      color,
-    });
+    if (verticalLine2Start && verticalLine2End) {
+      drawLine(
+        context,
+        referenceElement,
+        verticalLine2Start,
+        verticalLine2End,
+        {
+          color,
+        }
+      );
+    }
 
-    drawLine(
-      context,
-      referenceElement,
-      horizontalLine1Start,
-      horizontalLine1End,
-      {
-        color,
-      }
-    );
+    if (horizontalLine1Start && horizontalLine1End) {
+      drawLine(
+        context,
+        referenceElement,
+        horizontalLine1Start,
+        horizontalLine1End,
+        {
+          color,
+        }
+      );
+    }
 
-    drawLine(
-      context,
-      referenceElement,
-      horizontalLine2Start,
-      horizontalLine2End,
-      {
-        color,
-      }
-    );
+    if (horizontalLine2Start && horizontalLine2End) {
+      drawLine(
+        context,
+        referenceElement,
+        horizontalLine2Start,
+        horizontalLine2End,
+        {
+          color,
+        }
+      );
+    }
   });
 }

--- a/src/tools/crosshairs/renderCrosshairs.js
+++ b/src/tools/crosshairs/renderCrosshairs.js
@@ -1,0 +1,106 @@
+import external from './../../externalModules.js';
+import convertToVector3 from './../../util/convertToVector3.js';
+import { draw, drawLine } from './../../drawing/index.js';
+import { projectPatientPointToImagePlane } from '../../util/pointProjector.js';
+
+/**
+ * Renders the active reference line.
+ *
+ * @export @public @method
+ * @name renderCrosshairs
+ * @param  {Object} context        The canvas context.
+ * @param  {Object} eventData      The data associated with the event.
+ * @param  {HTMLElement} targetElement    The element on which to render the reference line.
+ * @param  {HTMLElement} referenceElement The element referenced by the line.
+ * @returns {void}
+ */
+export default function(
+  context,
+  eventData,
+  targetElement,
+  referenceElement,
+  patientPoint
+) {
+  const cornerstone = external.cornerstone;
+  const targetImage = cornerstone.getEnabledElement(targetElement).image;
+  const referenceImage = cornerstone.getEnabledElement(referenceElement).image;
+
+  // Make sure the images are actually loaded for the target and reference
+  if (!targetImage || !referenceImage) {
+    return;
+  }
+
+  const targetImagePlane = cornerstone.metaData.get(
+    'imagePlaneModule',
+    targetImage.imageId
+  );
+  const referenceImagePlane = cornerstone.metaData.get(
+    'imagePlaneModule',
+    referenceImage.imageId
+  );
+
+  // Make sure the target and reference actually have image plane metadata
+  if (
+    !targetImagePlane ||
+    !referenceImagePlane ||
+    !targetImagePlane.rowCosines ||
+    !targetImagePlane.columnCosines ||
+    !targetImagePlane.imagePositionPatient ||
+    !referenceImagePlane.rowCosines ||
+    !referenceImagePlane.columnCosines ||
+    !referenceImagePlane.imagePositionPatient
+  ) {
+    return;
+  }
+
+  // The image planes must be in the same frame of reference
+  if (
+    targetImagePlane.frameOfReferenceUID !==
+    referenceImagePlane.frameOfReferenceUID
+  ) {
+    return;
+  }
+
+  targetImagePlane.rowCosines = convertToVector3(targetImagePlane.rowCosines);
+  targetImagePlane.columnCosines = convertToVector3(
+    targetImagePlane.columnCosines
+  );
+  targetImagePlane.imagePositionPatient = convertToVector3(
+    targetImagePlane.imagePositionPatient
+  );
+  referenceImagePlane.rowCosines = convertToVector3(
+    referenceImagePlane.rowCosines
+  );
+  referenceImagePlane.columnCosines = convertToVector3(
+    referenceImagePlane.columnCosines
+  );
+  referenceImagePlane.imagePositionPatient = convertToVector3(
+    referenceImagePlane.imagePositionPatient
+  );
+
+  const projectedPatientPoint = projectPatientPointToImagePlane(
+    patientPoint,
+    referenceImagePlane
+  );
+
+  // Const color = toolColors.getActiveColor();
+  const color = '#A8D7FD';
+
+  // Draw the referenceLines
+  context.setTransform(1, 0, 0, 1, 0, 0);
+
+  const line1Start = { x: projectedPatientPoint.x, y: 0 };
+  const line1End = { x: projectedPatientPoint.x, y: referenceImage.height };
+  const line2Start = { x: 0, y: projectedPatientPoint.y };
+  const line2End = { x: referenceImage.width, y: projectedPatientPoint.y };
+
+  draw(context, context => {
+    drawLine(context, referenceElement, line1Start, line1End, {
+      color,
+    });
+
+    drawLine(context, referenceElement, line2Start, line2End, {
+      color,
+    });
+  });
+}

--- a/src/tools/crosshairs/renderCrosshairs.js
+++ b/src/tools/crosshairs/renderCrosshairs.js
@@ -4,14 +4,14 @@ import { draw, drawLine } from './../../drawing/index.js';
 import { projectPatientPointToImagePlane } from '../../util/pointProjector.js';
 
 /**
- * Renders the active reference line.
+ * Renders the livesync crosshairs.
  *
  * @export @public @method
  * @name renderCrosshairs
  * @param  {Object} context        The canvas context.
  * @param  {Object} eventData      The data associated with the event.
- * @param  {HTMLElement} targetElement    The element on which to render the reference line.
- * @param  {HTMLElement} referenceElement The element referenced by the line.
+ * @param  {HTMLElement} targetElement
+ * @param  {HTMLElement} referenceElement
  * @returns {void}
  */
 export default function(
@@ -83,7 +83,6 @@ export default function(
     referenceImagePlane
   );
 
-  // Const color = toolColors.getActiveColor();
   const color = '#A8D7FD';
 
   // Draw the referenceLines

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '6.0.10-ded20';
+export default '6.0.10-ded21';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '6.0.10-ded17';
+export default '6.0.10-ded18';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '6.0.10-ded21';
+export default '6.0.10-ded22';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '6.0.10-ded19';
+export default '6.0.10-ded20';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '6.0.10-ded18';
+export default '6.0.10-ded19';


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds in the **Cornerstone Tools** side of the crosshair drawing functionality to the **LiveSync** tool (**CrosshairsTool** in **Cornerstone Tools**).

The PR for the **Viewer** side of the functionality can be found here: https://github.com/DedalusDIIT/atlas/pull/2128

The implementation adds the **renderToolData** method which calls the Crosshairs renderer for each enabled element. 

A check that prevents any rendering from being done in cases where the same imageId index is found was removed. Previously it made sense to have it because only syncing of the viewports was done, so if the same image would be detected, there was no reason to do any rendering. Now with the newly added crosshairs, removing the check ensures that the position of the crosshairs is more accurately drawn.