### PR TITLE
DVISA-2642: Update runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: arc-runner
 
     strategy:
       matrix:


### PR DESCRIPTION
Update runners to use arc-runners

IMPORTANT :  DON NOT MERGET YET.

We need to move everything to be internal to be able to use arc-runners.