### PR TITLE
DVISA-874: Pixel calibration

### DIFF
--- a/locale/de.json
+++ b/locale/de.json
@@ -10,5 +10,6 @@
   "mm": "mm",
   "mm_prj": "mm (prj)",
   "mm_est": "mm (prj/schätz)",
-  "mm_approx": "mm (approx)"
+  "mm_approx": "mm (approx)",
+  "mm_man": "mm (man)"
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -10,5 +10,6 @@
   "mm": "mm",
   "mm_prj": "mm (prj)",
   "mm_est": "mm (prj/est)",
-  "mm_approx": "mm (approx)"
+  "mm_approx": "mm (approx)",
+  "mm_man": "mm (man)"
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -10,5 +10,6 @@
   "mm": "mm",
   "mm_prj": "mm (pry)",
   "mm_est": "mm (pry/est)",
-  "mm_approx": "mm (aprox)"
+  "mm_approx": "mm (aprox)",
+  "mm_man": "mm (man)"
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -10,5 +10,6 @@
   "mm": "mm",
   "mm_prj": "mm (prj)",
   "mm_est": "mm (prj/estimé)",
-  "mm_approx": "mm (approx)"
+  "mm_approx": "mm (approx)",
+  "mm_man": "mm (man)"
 }

--- a/locale/it.json
+++ b/locale/it.json
@@ -10,5 +10,6 @@
   "mm": "mm",
   "mm_prj": "mm (proiett.)",
   "mm_est": "mm (proiett./stima)",
-  "mm_approx": "mm (appros.)"
+  "mm_approx": "mm (appros.)",
+  "mm_man": "mm (man)"
 }

--- a/locale/nl.json
+++ b/locale/nl.json
@@ -10,5 +10,6 @@
   "mm": "mm",
   "mm_prj": "mm (proj)",
   "mm_est": "mm (proj/schatting)",
-  "mm_approx": "mm (ong)"
+  "mm_approx": "mm (ong)",
+  "mm_man": "mm (man)"
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -10,5 +10,6 @@
   "mm": "mm",
   "mm_prj": "mm (prj)",
   "mm_est": "mm (prj/est)",
-  "mm_approx": "mm (approx)"
+  "mm_approx": "mm (approx)",
+  "mm_man": "mm (man)"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedalusdiit/cornerstone-tools",
-  "version": "6.0.10-ded22",
+  "version": "6.0.10-ded23",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "keywords": [

--- a/src/util/pixelSpacing/getPixelSpacing.js
+++ b/src/util/pixelSpacing/getPixelSpacing.js
@@ -55,10 +55,22 @@ const isProjection = imagePlane => {
 };
 
 const getPixelSpacingAndUnit = obj => {
-  const rowPixelSpacing = obj.rowPixelSpacing || obj.rowImagePixelSpacing;
-  const colPixelSpacing = obj.columnPixelSpacing || obj.colImagePixelSpacing;
+  const rowPixelSpacing =
+    (obj.rowPixelSpacing || obj.rowImagePixelSpacing) *
+    (obj.calibrationFactor || 1);
+  const colPixelSpacing =
+    (obj.columnPixelSpacing || obj.colImagePixelSpacing) *
+    (obj.calibrationFactor || 1);
   const hasPixelSpacing = rowPixelSpacing && colPixelSpacing;
-  const unit = hasPixelSpacing ? 'mm' : 'pix';
+  const hasCalibrationFactor = obj.calibrationFactor;
+
+  let unit = 'pix';
+
+  if (hasCalibrationFactor && hasPixelSpacing) {
+    unit = 'mm (man)';
+  } else if (hasPixelSpacing) {
+    unit = 'mm';
+  }
 
   return {
     rowPixelSpacing,

--- a/src/util/pixelSpacing/getPixelSpacing.js
+++ b/src/util/pixelSpacing/getPixelSpacing.js
@@ -55,19 +55,23 @@ const isProjection = imagePlane => {
 };
 
 const getPixelSpacingAndUnit = obj => {
-  const rowPixelSpacing =
-    (obj.rowPixelSpacing || obj.rowImagePixelSpacing) *
-    (obj.calibrationFactor || 1);
-  const colPixelSpacing =
-    (obj.columnPixelSpacing || obj.colImagePixelSpacing) *
-    (obj.calibrationFactor || 1);
+  const baseRowPixelSpacing = obj.rowPixelSpacing || obj.rowImagePixelSpacing;
+  const baseColPixelSpacing =
+    obj.columnPixelSpacing || obj.colImagePixelSpacing;
+
+  const rowPixelSpacing = baseRowPixelSpacing
+    ? baseRowPixelSpacing * (obj.calibrationFactor || 1)
+    : baseRowPixelSpacing;
+  const colPixelSpacing = baseColPixelSpacing
+    ? baseColPixelSpacing * (obj.calibrationFactor || 1)
+    : baseColPixelSpacing;
   const hasPixelSpacing = rowPixelSpacing && colPixelSpacing;
   const hasCalibrationFactor = obj.calibrationFactor;
 
   let unit = 'pix';
 
   if (hasCalibrationFactor && hasPixelSpacing) {
-    unit = 'mm (man)';
+    unit = 'mm_man';
   } else if (hasPixelSpacing) {
     unit = 'mm';
   }

--- a/src/util/pixelSpacing/getPixelSpacing.js
+++ b/src/util/pixelSpacing/getPixelSpacing.js
@@ -66,7 +66,8 @@ const getPixelSpacingAndUnit = obj => {
     ? baseColPixelSpacing * (obj.calibrationFactor || 1)
     : baseColPixelSpacing;
   const hasPixelSpacing = rowPixelSpacing && colPixelSpacing;
-  const hasCalibrationFactor = obj.calibrationFactor;
+  const hasCalibrationFactor =
+    obj.calibrationFactor && obj.calibrationFactor !== 1;
 
   let unit = 'pix';
 

--- a/src/util/pixelSpacing/getPixelSpacing.test.js
+++ b/src/util/pixelSpacing/getPixelSpacing.test.js
@@ -139,7 +139,7 @@ describe('getPixelSpacing', () => {
     expect(result).toEqual({
       rowPixelSpacing: 50,
       colPixelSpacing: 100,
-      unit: 'mm (man)',
+      unit: 'mm_man',
     });
   });
 });

--- a/src/util/pixelSpacing/getPixelSpacing.test.js
+++ b/src/util/pixelSpacing/getPixelSpacing.test.js
@@ -119,4 +119,27 @@ describe('getPixelSpacing', () => {
 
     expect(getProjectionRadiographPixelSpacing).toHaveBeenCalledTimes(1);
   });
+
+  it('should return calibrated rowPixelSpacing and colPixelSpacing from imagePlane if calibration factor is present', () => {
+    const image = {
+      imageId: 'imageId',
+      rowPixelSpacing: 2,
+      columnPixelSpacing: 3,
+    };
+
+    external.cornerstone.metaData.get = jest.fn();
+    external.cornerstone.metaData.get.mockReturnValue({
+      rowPixelSpacing: 10,
+      columnPixelSpacing: 20,
+      calibrationFactor: 5,
+    });
+
+    const result = getPixelSpacing(image, null);
+
+    expect(result).toEqual({
+      rowPixelSpacing: 50,
+      colPixelSpacing: 100,
+      unit: 'mm (man)',
+    });
+  });
 });

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '6.0.10-ded22';
+export default '6.0.10-ded23';


### PR DESCRIPTION
This PR is part of the implementation of [DVISA-874](https://jira.dedalus.com/browse/DVISA-874).

`getPixelSpacing` method was extended to take into consideration the `calibrationFactor` of the image, which is passed over `InstanceMetadataProvider` in the atlas project.

Row and column pixel spacing are multiplied by the calibration factor, respectively. If the factor is present, the unit is set to "mm (man)".
