### PR TITLE
DVISA-2882: Support pixel calibration for projection radiograph SOP classes

### DIFF
--- a/src/util/pixelSpacing/getPixelSpacing.js
+++ b/src/util/pixelSpacing/getPixelSpacing.js
@@ -54,9 +54,18 @@ const isProjection = imagePlane => {
   return projectionRadiographSOPClassUIDs.includes(sopClassUid);
 };
 
-const determineUnit = (hasPixelSpacing, hasCalibrationFactor) => {
+const determineUnit = (
+  hasPixelSpacing,
+  hasCalibrationFactor,
+  calibrationReset,
+  isFirstCalibration
+) => {
   if (hasCalibrationFactor) {
     return 'mm_man';
+  }
+
+  if (calibrationReset) {
+    return isFirstCalibration ? 'pix' : 'mm_man';
   }
 
   return hasPixelSpacing ? 'mm' : 'pix';
@@ -77,7 +86,12 @@ const getPixelSpacingAndUnit = obj => {
   const hasCalibrationFactor =
     obj.calibrationFactor && obj.calibrationFactor !== 1;
 
-  const unit = determineUnit(hasPixelSpacing, hasCalibrationFactor);
+  const unit = determineUnit(
+    hasPixelSpacing,
+    hasCalibrationFactor,
+    obj.calibrationReset,
+    obj.isFirstCalibration
+  );
 
   return {
     rowPixelSpacing,

--- a/src/util/pixelSpacing/getPixelSpacing.test.js
+++ b/src/util/pixelSpacing/getPixelSpacing.test.js
@@ -161,4 +161,46 @@ describe('getPixelSpacing', () => {
       unit: 'mm_man',
     });
   });
+
+  it('should return pix units when calibration was reset on the FIRST calibration', () => {
+    const image = { imageId: 'imageId' };
+
+    external.cornerstone.metaData.get = jest.fn();
+    external.cornerstone.metaData.get.mockReturnValue({
+      rowPixelSpacing: 10,
+      columnPixelSpacing: 20,
+      calibrationFactor: 1,
+      calibrationReset: true,
+      isFirstCalibration: true,
+    });
+
+    const result = getPixelSpacing(image, null);
+
+    expect(result).toEqual({
+      rowPixelSpacing: 10,
+      colPixelSpacing: 20,
+      unit: 'pix',
+    });
+  });
+
+  it('should return mm_man units when calibration was reset AFTER at least one previous calibration', () => {
+    const image = { imageId: 'imageId' };
+
+    external.cornerstone.metaData.get = jest.fn();
+    external.cornerstone.metaData.get.mockReturnValue({
+      rowPixelSpacing: 10,
+      columnPixelSpacing: 20,
+      calibrationFactor: 1,
+      calibrationReset: true,
+      isFirstCalibration: false,
+    });
+
+    const result = getPixelSpacing(image, null);
+
+    expect(result).toEqual({
+      rowPixelSpacing: 10,
+      colPixelSpacing: 20,
+      unit: 'mm_man',
+    });
+  });
 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- added calibrationReset and isFirstCalibration to determineUnit()
- added unit tests


* **What is the current behavior?** (You can also link to an open issue here)
https://jira.dedalus.com/browse/DVISA-2896

* **What is the new behavior (if this is a feature change)?**
Measurement units don't switch to mm when they are not supposed to - e.g. when making a pixel calibration on a series when we have previously made calibrations on another series, the regular measurement now either stays in pix (if it's the first measurement) or it stays in mm_man if calibrations have already been made on a series.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
